### PR TITLE
connect the socket if not

### DIFF
--- a/dist/client.js
+++ b/dist/client.js
@@ -85,6 +85,7 @@ var SocketIOClient = (function (_Client) {
       if (this._ioClient === null) {
         (function () {
           _this2._ioClient = new _socketIoClient2['default'](_this2._uri, _this2._sockOpts);
+          _this2._ioClient.connect();
           var receiveFromSocket = function receiveFromSocket(json) {
             return _this2.receiveFromSocket(json);
           };

--- a/src/client.js
+++ b/src/client.js
@@ -32,6 +32,7 @@ class SocketIOClient extends Client {
   get _io() {
     if(this._ioClient === null) {
       this._ioClient = new IOClient(this._uri, this._sockOpts);
+      this._ioClient.connect();
       const receiveFromSocket = (json) => this.receiveFromSocket(json);
       const forceResync = () => this.forceResync();
       this._ioClient.on(this._salt, receiveFromSocket);


### PR DESCRIPTION
Lorsque le socket est récupéré depuis le cache, la connexion n'est pas exécutée. J'ai donc rajouté le ioClient.connect() qui permet d'effectuer la connexion si celle-ci n'est pas déjà établie.
